### PR TITLE
Remove merge commits from full commit log

### DIFF
--- a/detect/git/git.go
+++ b/detect/git/git.go
@@ -29,7 +29,7 @@ func GitLog(source string, logOpts LogOpts, errChan chan error) (<-chan *gitdiff
 		cmd = exec.Command("git", args...)
 	} else {
 		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0",
-			"--full-history", "--all")
+			"--full-history", "--all", "--no-merge")
 	}
 	if logOpts.DisableSafeDir {
 		absPath, err := filepath.Abs(source)


### PR DESCRIPTION
### Description:
GitLog doesn't properly split out merge commits, because those commits don't include changed files. This causes secrets to be misreported as being in the merge commit, rather than their actual commit. Removing them should solve that issue.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
