### PR TITLE
Remove all commits without changes from the git log

### DIFF
--- a/detect/git/git.go
+++ b/detect/git/git.go
@@ -29,7 +29,7 @@ func GitLog(source string, logOpts LogOpts, errChan chan error) (<-chan *gitdiff
 		cmd = exec.Command("git", args...)
 	} else {
 		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0",
-			"--full-history", "--all", "--no-merges")
+			"--full-history", "--all", "-G.")
 	}
 	if logOpts.DisableSafeDir {
 		absPath, err := filepath.Abs(source)


### PR DESCRIPTION
Turns out we don't actually care about merge commits specifically, but all commits that don't have changes break the commit + file parsing.

Note, this change _does_ slow things down. Between 10% and 48% time wise, based on tests. But it's not computationally more difficult, and that 10% was on a very large repo, so the big slowdowns are really only in the smaller repos.