### PR TITLE
Only filter noops

### DIFF
--- a/detect/git/git.go
+++ b/detect/git/git.go
@@ -29,7 +29,7 @@ func GitLog(source string, logOpts LogOpts, errChan chan error) (<-chan *gitdiff
 		cmd = exec.Command("git", args...)
 	} else {
 		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0",
-			"--full-history", "--all", "-G.")
+			"--full-history", "--all", "--diff-filter=ACDMRTUXB")
 	}
 	if logOpts.DisableSafeDir {
 		absPath, err := filepath.Abs(source)


### PR DESCRIPTION
`-G.` removes binary commits and newline-only commits. `--diff-filter=ACDMRTUXB` will include commits that have any type of file changes. We could probably limit it to just `AM`, but that could introduce other unexpected errors in the log parsing.